### PR TITLE
Allow for callable to require()

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -339,7 +339,13 @@ class Command implements \ArrayAccess, \Iterator
 
             // todo protect against duplicates caused by aliases
             foreach ($this->options as $option) {
-                if (is_null($option->getValue()) && $option->isRequired()) {
+                $required = $option->getRequired();
+
+                if (is_callable($required)) {
+                    $required = call_user_func($required);
+                }
+
+                if (is_null($option->getValue()) && $required) {
                     throw new \Exception(sprintf('Required %s %s must be specified',
                         $option->getType() & Option::TYPE_NAMED ?
                             'option' : 'argument', $option->getName()));

--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -211,6 +211,14 @@ class Option
     }
 
     /**
+     * @return bool|callable
+     */
+    public function getRequired()
+    {
+        return $this->required;
+    }
+
+    /**
      * @return array list of aliases
      */
     public function getAliases()
@@ -240,7 +248,7 @@ class Option
      */
     public function isRequired()
     {
-        return $this->required;
+        return is_bool($this->required) ? $this->required : false;
     }
 
     /**

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -120,4 +120,48 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('a' => 'v1', 'b' => 'v2'), $cmd->getFlagValues());
     }
 
+    public function testRequireBool()
+    {
+        $this->setExpectedException('\Exception');
+
+        // -a is not specified, ergo an exception should be thrown because it is required
+        $tokens = array('filename');
+        $cmd = new Command($tokens);
+        $cmd->trapErrors(false);
+        $cmd->option('a')->require(true);
+        $cmd->parse();
+    }
+
+    public function testRequireCallableTrue()
+    {
+        $this->setExpectedException('\Exception');
+
+        // -a is not specified, ergo b is required and an exception should be thrown
+        $tokens = array('filename');
+        $cmd = new Command($tokens);
+        $cmd->trapErrors(false);
+        $cmd->option('a');
+        $cmd->option('b')->require(function() use($cmd){
+            return $cmd->getOption('a')->getValue() == null;
+        });
+        $cmd->parse();
+    }
+
+    public function testRequireCallableFalse()
+    {
+        try { 
+            // -a is not specified, ergo b is required and an exception should not be thrown
+            $tokens = array('filename', '-b', '1');
+            $cmd = new Command($tokens);
+            $cmd->trapErrors(false);
+            $cmd->option('a');
+            $cmd->option('b')->require(function() use($cmd){
+                return $cmd->getOption('a')->getValue() == null;
+            });
+            $cmd->parse();
+        } catch (\Exception $e) {
+            var_dump($e->getMessage());
+            $this->fail('An unexpected exception has been raised.');
+        }
+    }
 }


### PR DESCRIPTION
This change would allow for you to pass a callable into the require method and have it be evaluated when determining if the option is required. An example of why this might be used can be seen here:

``` php
<?php
include './vendor/autoload.php';

$cmd = new Commando\Command();

$cmd->option('n')
    ->describedAs('Full Name');

$cmd->option('f')
    ->describedAs('First Name')
    ->require(function() use ($cmd){
        return $cmd->getOption('n')->getValue() == null;
    });

$cmd->option('l')
    ->describedAs('Last Name')
    ->require(function() use ($cmd){
        return $cmd->getOption('n')->getValue() == null;
    });

print (is_null($cmd['n']) ? $cmd['f'] . ' ' . $cmd['l'] : $cmd['n']) . PHP_EOL;
```

I've been working around this at work and thought it might be worth seeing if the use case merited an upstream change.

We have a number of scripts that use commando and take either a host of configuration options or a configuration file that supplies them.  In the event of the configuration file all of the required configuration options become required.  We wind up doing a lot of this to work around it...

``` php
if ($cmd['n'] == null & $cmd['f'] == null) throw new \Exception("Missing requirement!");
```
