### PR TITLE
Fix for needs() incorrect behavior

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -367,16 +367,6 @@ class Command implements \ArrayAccess, \Iterator
                 }
             }
 
-            // See if our options have what they require
-            foreach ($this->options as $option) {
-                $needs = $option->hasNeeds($this->options);
-                if ($needs !== true) {
-                    throw new \InvalidArgumentException(
-                        'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
-                    );
-                }
-            }
-
             // Set values (validates and performs map when applicable)
             foreach ($keyvals as $key => $value) {
 
@@ -389,6 +379,16 @@ class Command implements \ArrayAccess, \Iterator
                     throw new \Exception(sprintf('Required %s %s must be specified',
                         $option->getType() & Option::TYPE_NAMED ?
                             'option' : 'argument', $option->getName()));
+                }
+            }
+
+            // See if our options have what they require
+            foreach ($this->options as $option) {
+                $needs = $option->hasNeeds($this->options);
+                if ($needs !== true) {
+                    throw new \InvalidArgumentException(
+                        'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
+                    );
                 }
             }
 

--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -306,6 +306,11 @@ class Option
         $notFound = array();
         foreach ($needs as $need) {
             if (!in_array($need, $definedOptions)) {
+                // The needed option has not been defined as a valid flag.
+                $notFound[] = $need;
+            } elseif (!$optionsList[$need]->getValue()) {
+                // The needed option has been defined as a valid flag, but was
+                // not pased in by the user.
                 $notFound[] = $need;
             }
         }

--- a/tests/Commando/OptionTest.php
+++ b/tests/Commando/OptionTest.php
@@ -149,11 +149,31 @@ class OptionTest extends \PHPUnit_Framework_TestCase
     {
         $option = new Option('f');
         $option->setNeeds('foo');
+        $neededOption = new Option('foo');
+        $neededOption->setValue(true);
         $optionSet = array(
-            'foo' => new Option('foo')
+            'foo' => $neededOption,
         );
 
         $this->assertTrue($option->hasNeeds($optionSet));
+    }
+
+    /**
+     * Test hasNeeds when requirements are not met.
+     * @test
+     */
+    public function testOptionRequiresNotMet()
+    {
+        $option = new Option('f');
+        $option->setNeeds('foo');
+        $optionSet = array(
+            'foo' => new Option('foo'),
+        );
+
+        $expected = array(
+            'foo',
+        );
+        $this->assertEquals($expected, $option->hasNeeds($optionSet));
     }
 
     // Providers


### PR DESCRIPTION
Moved the check to see if needs are met until after the command line flags are
processed so the check can see if an option is both defined and passed in by the
user. Added unit tests to cover fix as well.

nategood/commando/issues#34
