### PR TITLE
Dev

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -428,7 +428,7 @@ class Command implements \ArrayAccess, \Iterator
                     if ($option->isBoolean()) {
                         $keyvals[$arg_name] = !$option->getDefault(); // inverse of the default, as expected
                     } else {
-                        if ($arg_type == self::OPTION_TYPE_VERBOSE_EQUALS) {
+                        if ($arg_type === self::OPTION_TYPE_VERBOSE_EQUALS) {
                             //If the option is of the --option=value type
                             //the option value is contained within the token - so we extract it here
                             $argument_value = $this->extractEqualsOptionValue($token);
@@ -452,16 +452,7 @@ class Command implements \ArrayAccess, \Iterator
                 }
             }
 
-            // See if our options have what they require
-            foreach ($this->options as $option) {
-                $needs = $option->hasNeeds($keyvals);
-                if ($needs !== true) {
-                    throw new \InvalidArgumentException(
-                        'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
-                    );
-                }
-            }
-            
+
             // Set values (validates and performs map when applicable)
             foreach ($keyvals as $key => $value) {
                 $this->getOption($key)->setValue($value);
@@ -476,6 +467,17 @@ class Command implements \ArrayAccess, \Iterator
                 }
             }
 
+            // See if our options have what they require
+            foreach ($this->options as $option) {
+                $needs = $option->hasNeeds($this->options);
+                if ($needs !== true) {
+                    throw new \InvalidArgumentException(
+                        'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
+                    );
+                }
+            }
+            
+            
             // keep track of our argument vs. flag keys
             // done here to allow for flags/arguments added
             // at run time.  okay because option values are

--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -45,6 +45,7 @@ class Command implements \ArrayAccess, \Iterator
     const OPTION_TYPE_ARGUMENT  = 1; // e.g. foo
     const OPTION_TYPE_SHORT     = 2; // e.g. -u
     const OPTION_TYPE_VERBOSE   = 4; // e.g. --username
+    const OPTION_TYPE_VERBOSE_EQUALS = 5; // e.g. --username=
 
     private
         $current_option             = null,
@@ -116,7 +117,15 @@ class Command implements \ArrayAccess, \Iterator
         'defaultsTo' => 'default',
     );
 
-    public function __construct($tokens = null)
+    /**
+     * @param array|null $tokens
+     * Beware if tokens are manually supplied that the first element of the array 
+     * is array_shifted off the array and more or less discarded. 
+     * This is to substitute for the "executed filename" arg which is present as the
+     * first element in the usually used $_SERVER['argv'] array.
+     * 
+     */
+    public function __construct(array $tokens = null)
     {
         if (empty($tokens)) {
             $tokens = $_SERVER['argv'];
@@ -356,6 +365,25 @@ class Command implements \ArrayAccess, \Iterator
     }
 
     /**
+     * Extracts the value of an equals option
+     * E.g. The argument --option=value given to this method will return "value"
+     * @param type $cli_argument
+     * @return String or NULL
+     * @throws Exception
+     */
+    private function extractEqualsOptionValue($cli_argument) {
+        if (strpos($cli_argument, "=") === FALSE) {
+            throw new Exception("Expected an equals character");
+        }
+
+        $value = trim(substr(strstr($cli_argument, "="), 1));
+        if($value != ""){
+            return $value;
+        }
+        return NULL;
+    }
+
+    /**
      * @throws \Exception
      * @return void
      */
@@ -374,11 +402,11 @@ class Command implements \ArrayAccess, \Iterator
             while (!empty($tokens)) {
                 $token = array_shift($tokens);
 
-                list($name, $type) = $this->_parseOption($token);
+                list($arg_name, $arg_type) = $this->_parseOption($token);
 
-                if ($type === self::OPTION_TYPE_ARGUMENT) {
+                if ($arg_type === self::OPTION_TYPE_ARGUMENT) {
                     // its an argument, use an int as the index
-                    $keyvals[$count] = $name;
+                    $keyvals[$count] = $arg_name;
 
                     // We allow for "dynamic" anonymous arguments, so we
                     // add an option for any anonymous arguments that
@@ -390,28 +418,52 @@ class Command implements \ArrayAccess, \Iterator
                     $count++;
                 } else {
                     // Short circuit if the help flag was set and we're using default help
-                    if ($this->use_default_help === true && $name === 'help') {
+                    if ($this->use_default_help === true && $arg_name === 'help') {
                         $this->printHelp();
                         exit;
                     }
 
-                    $option = $this->getOption($name);
+                    $option = $this->getOption($arg_name);
+
                     if ($option->isBoolean()) {
-                        $keyvals[$name] = !$option->getDefault();// inverse of the default, as expected
+                        $keyvals[$arg_name] = !$option->getDefault(); // inverse of the default, as expected
                     } else {
-                        // the next token MUST be an "argument" and not another flag/option
-                        $token = array_shift($tokens);
-                        list($val, $type) = $this->_parseOption($token);
-                        if ($type !== self::OPTION_TYPE_ARGUMENT)
-                            throw new \Exception(sprintf('Unable to parse option %s: Expected an argument', $token));
-                        $keyvals[$name] = $val;
+                        if ($arg_type == self::OPTION_TYPE_VERBOSE_EQUALS) {
+                            //If the option is of the --option=value type
+                            //the option value is contained within the token - so we extract it here
+                            $argument_value = $this->extractEqualsOptionValue($token);
+                        } else {
+                            // If the argument is of a --option value type
+                            // the next token in the tokens array MUST be an "argument" and not another flag/option
+                            $argument_value = array_shift($tokens);
+                        }
+                        
+                        //If the argument_value is not clean (more or less if it contains
+                        //a hyphen and so is actually another hyphenated option) - fail.  
+                        //Isn't this a misuse of _parseOption?
+                        //Should there be a method called _parseArgumentValue for this?
+                        list($val, $value_type) = $this->_parseOption($argument_value);                        
+                        if ($value_type === self::OPTION_TYPE_ARGUMENT){
+                            $keyvals[$arg_name] = $val;
+                        }else{
+                            throw new \Exception(sprintf('Unable to parse option %s: Expected an argument', $argument_value));
+                        }
                     }
                 }
             }
 
+            // See if our options have what they require
+            foreach ($this->options as $option) {
+                $needs = $option->hasNeeds($keyvals);
+                if ($needs !== true) {
+                    throw new \InvalidArgumentException(
+                        'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
+                    );
+                }
+            }
+            
             // Set values (validates and performs map when applicable)
             foreach ($keyvals as $key => $value) {
-
                 $this->getOption($key)->setValue($value);
             }
 
@@ -421,16 +473,6 @@ class Command implements \ArrayAccess, \Iterator
                     throw new \Exception(sprintf('Required %s %s must be specified',
                         $option->getType() & Option::TYPE_NAMED ?
                             'option' : 'argument', $option->getName()));
-                }
-            }
-
-            // See if our options have what they require
-            foreach ($this->options as $option) {
-                $needs = $option->hasNeeds($this->options);
-                if ($needs !== true) {
-                    throw new \InvalidArgumentException(
-                        'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
-                    );
                 }
             }
 
@@ -488,20 +530,33 @@ class Command implements \ArrayAccess, \Iterator
     {
         $matches = array();
 
-        if (substr($token, 0, 1) === '-' && !preg_match('/(?P<hyphen>\-{1,2})(?P<name>[a-z][a-z0-9_-]*)/i', $token, $matches)) {
+        if (substr($token, 0, 1) === '-' && !preg_match('/(?P<hyphen>\-{1,2})(?P<name>[a-z][a-z0-9_-]*(?P<equals>\=){0,1})/i', $token, $matches)) {
             throw new \Exception(sprintf('Unable to parse option %s: Invalid syntax', $token));
         }
 
         if (!empty($matches['hyphen'])) {
-            $type = (strlen($matches['hyphen']) === 1) ?
-                self::OPTION_TYPE_SHORT:
-                self::OPTION_TYPE_VERBOSE;
-            return array($matches['name'], $type);
+            $type;
+            $name = $matches['name'];
+            $hyphen_count = strlen($matches['hyphen']);
+            switch ($hyphen_count) {
+                case 1:
+                    $type = self::OPTION_TYPE_SHORT;
+                    break;
+                case 2:
+                    if (array_key_exists("equals", $matches) && !empty($matches["equals"])) {
+                        $type = self::OPTION_TYPE_VERBOSE_EQUALS;
+                        $name = str_replace("=", "", $name);
+                    } else {
+                        $type = self::OPTION_TYPE_VERBOSE;
+        }
+                    break;
+            }
+
+            return array($name, $type);
         }
 
         return array($token, self::OPTION_TYPE_ARGUMENT);
     }
-
 
     /**
      * @param string $option

--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Commando;
+
 use \Commando\Util\Terminal;
 
 /**
@@ -36,45 +37,43 @@ use \Commando\Util\Terminal;
  * @method Option expectsFile ()
  *
  */
+class Option {
 
-class Option
-{
     private
-        $name, /* string optional name of argument */
-        $title, /* a formal way to reference this argument */
-        $aliases = array(), /* aliases for this argument */
-        $value = null, /* mixed */
-        $description, /* string */
-        $required = false, /* bool */
-        $needs = array(), /* set of other required options for this option */
-        $boolean = false, /* bool */
-        $type = 0, /* int see constants */
-        $rule, /* closure */
-        $map, /* closure */
-        $default, /* mixed default value for this option when no value is specified */
-        $file = false, /* bool */
-        $file_require_exists, /* bool require that the file path is valid */
-        $file_allow_globbing; /* bool allow globbing for files */
+            $name, /* string optional name of argument */
+            $title, /* a formal way to reference this argument */
+            $aliases = array(), /* aliases for this argument */
+            $value = null, /* mixed */
+            $description, /* string */
+            $required = false, /* bool */
+            $needs = array(), /* set of other required options for this option */
+            $boolean = false, /* bool */
+            $type = 0, /* int see constants */
+            $rule, /* closure */
+            $map, /* closure */
+            $default, /* mixed default value for this option when no value is specified */
+            $file = false, /* bool */
+            $file_require_exists, /* bool require that the file path is valid */
+            $file_allow_globbing; /* bool allow globbing for files */
 
-    const TYPE_SHORT        = 1;
-    const TYPE_VERBOSE      = 2;
-    const TYPE_NAMED        = 3; // 1|2
-    const TYPE_ANONYMOUS    = 4;
+    const TYPE_SHORT = 1;
+    const TYPE_VERBOSE = 2;
+    const TYPE_NAMED = 3; // 1|2
+    const TYPE_ANONYMOUS = 4;
 
     /**
      * @param string|int $name single char name or int index for this option
      * @return Option
      * @throws \Exception
      */
-    public function __construct($name)
-    {
+    public function __construct($name) {
         if (!is_int($name) && empty($name)) {
             throw new \Exception(sprintf('Invalid option name %s: Must be identified by a single character or an integer', $name));
         }
 
         if (!is_int($name)) {
             $this->type = mb_strlen($name, 'UTF-8') === 1 ?
-                self::TYPE_SHORT : self::TYPE_VERBOSE;
+                    self::TYPE_SHORT : self::TYPE_VERBOSE;
         } else {
             $this->type = self::TYPE_ANONYMOUS;
         }
@@ -86,8 +85,7 @@ class Option
      * @param string $alias
      * @return Option
      */
-    public function addAlias($alias)
-    {
+    public function addAlias($alias) {
         $this->aliases[] = $alias;
         return $this;
     }
@@ -96,8 +94,7 @@ class Option
      * @param string $description
      * @return Option
      */
-    public function setDescription($description)
-    {
+    public function setDescription($description) {
         $this->description = $description;
         return $this;
     }
@@ -106,10 +103,9 @@ class Option
      * @param bool $bool
      * @return Option
      */
-    public function setBoolean($bool = true)
-    {
+    public function setBoolean($bool = true) {
         // if we didn't define a default already, set false as the default value...
-        if($this->default === null) {
+        if ($this->default === null) {
             $this->setDefault(false);
         }
         $this->boolean = $bool;
@@ -129,8 +125,7 @@ class Option
      * @param bool $allow_globbing
      * @throws \Exception if the file does not exists
      */
-    public function setFileRequirements($require_exists = true, $allow_globbing = true)
-    {
+    public function setFileRequirements($require_exists = true, $allow_globbing = true) {
         $this->file = true;
         $this->file_require_exists = $require_exists;
         $this->file_allow_globbing = $allow_globbing;
@@ -140,8 +135,7 @@ class Option
      * @param string $title
      * @return Option
      */
-    public function setTitle($title)
-    {
+    public function setTitle($title) {
         $this->title = $title;
         return $this;
     }
@@ -150,8 +144,7 @@ class Option
      * @param bool $bool required?
      * @return Option
      */
-    public function setRequired($bool = true)
-    {
+    public function setRequired($bool = true) {
         $this->required = $bool;
         return $this;
     }
@@ -162,8 +155,7 @@ class Option
      * @param string $option Option name
      * @return Option
      */
-    public function setNeeds($option)
-    {
+    public function setNeeds($option) {
         if (!is_array($option)) {
             $option = array($option);
         }
@@ -177,8 +169,7 @@ class Option
      * @param mixed $value default value
      * @return Option
      */
-    public function setDefault($value)
-    {
+    public function setDefault($value) {
         $this->default = $value;
         $this->setValue($value);
         return $this;
@@ -187,8 +178,7 @@ class Option
     /**
      * @return mixed
      */
-    public function getDefault()
-    {
+    public function getDefault() {
         return $this->default;
     }
 
@@ -196,8 +186,7 @@ class Option
      * @param \Closure|string $rule regex, closure
      * @return Option
      */
-    public function setRule($rule)
-    {
+    public function setRule($rule) {
         $this->rule = $rule;
         return $this;
     }
@@ -206,8 +195,7 @@ class Option
      * @param \Closure
      * @return Option
      */
-    public function setMap(\Closure $map)
-    {
+    public function setMap(\Closure $map) {
         $this->map = $map;
         return $this;
     }
@@ -216,29 +204,24 @@ class Option
      * @param \Closure|string $value regex, closure
      * @return Option
      */
-    public function map($value)
-    {
+    public function map($value) {
         if (!is_callable($this->map))
             return $value;
 
         // todo add int, float and regex special case
-
         // todo double check syntax
         return call_user_func($this->map, $value);
     }
-
 
     /**
      * @param mixed $value
      * @return bool
      */
-    public function validate($value)
-    {
+    public function validate($value) {
         if (!is_callable($this->rule))
             return true;
 
         // todo add int, float and regex special case
-
         // todo double check syntax
         return call_user_func($this->rule, $value);
     }
@@ -248,8 +231,7 @@ class Option
      * @return string|array full file path or an array of file paths in the
      *     case where "globbing" is supported
      */
-    public function parseFilePath($file_path)
-    {
+    public function parseFilePath($file_path) {
         $path = realpath($file_path);
         if ($this->file_allow_globbing) {
             $files = glob($file_path);
@@ -267,32 +249,28 @@ class Option
     /**
      * @return string|int name of the option
      */
-    public function getName()
-    {
+    public function getName() {
         return $this->name;
     }
 
     /**
      * @return int type (see OPTION_TYPE_CONST)
      */
-    public function getType()
-    {
+    public function getType() {
         return $this->type;
     }
 
     /**
      * @return mixed value of the option
      */
-    public function getValue()
-    {
+    public function getValue() {
         return $this->value;
     }
 
     /**
      * @return array list of aliases
      */
-    public function getAliases()
-    {
+    public function getAliases() {
         return $this->aliases;
     }
 
@@ -300,16 +278,14 @@ class Option
      * Get the current set of this option's requirements
      * @return array List of required options
      */
-    public function getNeeds()
-    {
+    public function getNeeds() {
         return $this->needs;
     }
 
     /**
      * @return bool is this option a boolean
      */
-    public function isBoolean()
-    {
+    public function isBoolean() {
         // $this->value = false; // ?
         return $this->boolean;
     }
@@ -317,16 +293,14 @@ class Option
     /**
      * @return bool is this option a boolean
      */
-    public function isFile()
-    {
+    public function isFile() {
         return $this->file;
     }
 
     /**
      * @return bool is this option required?
      */
-    public function isRequired()
-    {
+    public function isRequired() {
         return $this->required;
     }
 
@@ -336,14 +310,15 @@ class Option
      * @param array $optionsList Set of current options defined
      * @return boolean|array True if requirements met, array if not found
      */
-    public function hasNeeds($optionsList)
-    {
+    public function hasNeeds($optionsList) {
+
         $needs = $this->getNeeds();
 
         $definedOptions = array_keys($optionsList);
         $notFound = array();
         foreach ($needs as $need) {
-            if (!in_array($need, $definedOptions)) {
+//var_Dump($need,$definedOptions);
+            if (!in_array($need, $definedOptions, true)) {
                 // The needed option has not been defined as a valid flag.
                 $notFound[] = $need;
             } elseif (!$optionsList[$need]->getValue()) {
@@ -353,15 +328,13 @@ class Option
             }
         }
         return (empty($notFound)) ? true : $notFound;
-
     }
 
     /**
      * @param mixed $value for this option (set on the command line)
      * @throws \Exception
      */
-    public function setValue($value)
-    {
+    public function setValue($value) {
         if ($this->isBoolean() && !is_bool($value)) {
             throw new \Exception(sprintf('Boolean option expected for option %s, received %s value instead', $this->name, $value));
         }
@@ -384,20 +357,19 @@ class Option
     /**
      * @return string
      */
-    public function getHelp()
-    {
+    public function getHelp() {
         $color = new \Colors\Color();
         $help = '';
 
         $isNamed = ($this->type & self::TYPE_NAMED);
 
         if ($isNamed) {
-            $help .=  PHP_EOL . (mb_strlen($this->name, 'UTF-8') === 1 ?
-                '-' : '--') . $this->name;
+            $help .= PHP_EOL . (mb_strlen($this->name, 'UTF-8') === 1 ?
+                            '-' : '--') . $this->name;
             if (!empty($this->aliases)) {
-                foreach($this->aliases as $alias) {
+                foreach ($this->aliases as $alias) {
                     $help .= (mb_strlen($alias, 'UTF-8') === 1 ?
-                        '/-' : '/--') . $alias;
+                                    '/-' : '/--') . $alias;
                 }
             }
             if (!$this->isBoolean()) {
@@ -412,7 +384,7 @@ class Option
         $help = $color->bold($help);
 
         $titleLine = '';
-        if($isNamed && $this->title) {
+        if ($isNamed && $this->title) {
             $titleLine .= $this->title . '.';
             if ($this->isRequired()) {
                 $titleLine .= ' ';
@@ -423,16 +395,15 @@ class Option
             $titleLine .= $color->red('Required.');
         }
 
-        if($titleLine){
+        if ($titleLine) {
             $titleLine .= ' ';
         }
         $description = $titleLine . $this->description;
         if (!empty($description)) {
             $descriptionArray = explode(PHP_EOL, trim($description));
-            foreach($descriptionArray as $descriptionLine){
+            foreach ($descriptionArray as $descriptionLine) {
                 $help .= Terminal::wrap($descriptionLine, 5, 1) . PHP_EOL;
             }
-
         }
 
         return $help;
@@ -441,8 +412,8 @@ class Option
     /**
      * @return string
      */
-    public function __toString()
-    {
+    public function __toString() {
         return $this->getHelp();
     }
+
 }

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -33,11 +33,12 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($tokens[2], $cmd['foo']);
 
         // Multiple flags
-        $tokens = array('filename', '-f', 'val', '-g', 'val2');
+	$tokens = array('filename', '-f', 'val', '-g', 'val2','--path=testpath');
         $cmd = new Command($tokens);
-        $cmd->option('f')->option('g');
+        $cmd->option('f')->option('g')->option('path');
         $this->assertEquals($tokens[2], $cmd['f']);
         $this->assertEquals($tokens[4], $cmd['g']);
+	$this->assertEquals("testpath", $cmd['path']);
 
         // Single flag with anonnymous argument
         $tokens = array('filename', '-f', 'val', 'arg1');
@@ -59,6 +60,13 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->argument();
         $this->assertEquals($tokens[3], $cmd[0]);
         $this->assertEquals($tokens[2], $cmd['f']);
+
+	// Verbose equals named argument
+        $tokens = array('filename','--filename=testfilename');
+        $cmd = new Command($tokens);
+        $cmd->option('filename');
+        $this->assertEquals("testfilename", $cmd['filename']);
+
     }
 
     public function testImplicitAndExplicitParse()
@@ -175,11 +183,11 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     {
         $tokens = array('filename', '-a', 'v1');
         $cmd = new Command($tokens);
-
         $cmd->trapErrors(false)
-            ->beepOnError(false);
+           ->beepOnError(false);
         $cmd->option('a')
         ->needs('b');
     }
+
 
 }


### PR DESCRIPTION
Hi,

After a false start I've uploaded a version that enables --option=value style arguments.  This is a fairly widely used method of passing in automatically generated arguments to a script (in our case our system uses it extensively).

It also adds a couple of tests for it.


There's a bug in the current dev branch Option::hasNeeds method that I've fixed - the in_array call wasn't using strict and was crashing on my tests as it was passing everything.  This is happening because for whatever reason there's always an integer 0 in the "$definedOptions" array that is used in the method to check which options have been passed in allowing it to always return true. 



The offending code is the first line in the below block:

```php
if (!in_array($need, $definedOptions)) { <---- contains a 0 so matches any string in $need
                // The needed option has not been defined as a valid flag.
                $notFound[] = $need;
            } elseif (!$optionsList[$need]->getValue()) {
                // The needed option has been defined as a valid flag, but was
                // not pased in by the user.
                $notFound[] = $need;
            }
```

The first line should be (and in my version has been changed to be):

```php
if (!in_array($need, $definedOptions, true)) {
```

There should probably be a proper method for it which loops through the array and does a proper comparison..

Finally I made a few small readability improvements in the Command::parse() method as it was getting confusing.