### PR TITLE
Make tput OS aware

### DIFF
--- a/src/Commando/Util/Terminal.php
+++ b/src/Commando/Util/Terminal.php
@@ -50,6 +50,11 @@ class Terminal
      */
     private static function tput($default, $param = 'cols')
     {
+    	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+    		return $default;
+    	$path = trim(shell_exec('which tput'));
+    	if (empty($path))
+    		return $default;
         $test = exec('tput ' . $param . ' 2>/dev/null');
         if (empty($test))
             return $default;


### PR DESCRIPTION
On Windows tput causes error messages. To prevent this, a check has been introduced so that it's not tried to execute tput.
Also on Linux it is now checked with "which" if tput is available before being called.
