### PR TITLE
Commando::define() return instance of the callee class

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -145,7 +145,7 @@ class Command implements \ArrayAccess, \Iterator
      */
     public static function define($tokens = null)
     {
-        return new Command($tokens);
+        return new static($tokens);
     }
 
     /**

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -218,7 +218,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testDefineFromSubclass()
     {
-        $cmd = AnotherCommand::define([]);
+        $cmd = AnotherCommand::define(['filename']);
 
         $this->assertInstanceOf('Commando\Test\AnotherCommand', $cmd);
     }

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -7,6 +7,13 @@ require dirname(dirname(__DIR__)) . '/vendor/autoload.php';
 use Commando\Option;
 use Commando\Command;
 
+/**
+ * Subclass of Command which is used by the sub class instanciation tests
+ * @class AnotherCommand
+ */
+class AnotherCommand extends Command {
+}
+
 class CommandTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -206,4 +213,13 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         ->needs('b');
     }
 
+    /**
+     * Test that define returned the instance of sub class when invoked from sub class
+     */
+    public function testDefineFromSubclass()
+    {
+        $cmd = AnotherCommand::define([]);
+
+        $this->assertInstanceOf('Commando\Test\AnotherCommand', $cmd);
+    }
 }

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -218,7 +218,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testDefineFromSubclass()
     {
-        $cmd = AnotherCommand::define(['filename']);
+        $cmd = AnotherCommand::define(array('filename'));
 
         $this->assertInstanceOf('Commando\Test\AnotherCommand', $cmd);
     }


### PR DESCRIPTION
if Command::define() is called from subclass of Command class,
it returns the instance of that subclass instead of Commando\Command.