### PR TITLE
Update unit tests for PHPUnit 6+

### DIFF
--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -139,7 +139,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->boolean();
         $this->assertTrue($cmd['b']);
     }
-    
+
     public function testIncrementOption()
     {
         $tokens = array('filename', '-vvvv');
@@ -148,10 +148,10 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->flag('v')
             ->aka('verbosity')
             ->increment();
-        
+
         $this->assertEquals(4, $cmd['verbosity']);
     }
-    
+
     public function testIncrementOptionMaxValue()
     {
         $tokens = array('filename', '-vvvv');
@@ -160,7 +160,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->flag('v')
             ->aka('verbosity')
             ->increment(3);
-            
+
         $this->assertEquals(3, $cmd['verbosity']);
     }
 

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -7,7 +7,7 @@ require dirname(dirname(__DIR__)) . '/vendor/autoload.php';
 use Commando\Option;
 use Commando\Command;
 
-class CommandTest extends \PHPUnit_Framework_TestCase
+class CommandTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testCommandoAnon()

--- a/tests/Commando/OptionTest.php
+++ b/tests/Commando/OptionTest.php
@@ -7,7 +7,7 @@ require dirname(dirname(__DIR__)) . '/vendor/autoload.php';
 use Commando\Option;
 use Commando\Commando;
 
-class OptionTest extends \PHPUnit_Framework_TestCase
+class OptionTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testNamedOption()


### PR DESCRIPTION
PHPUnit 6+ has changed from the old PEAR style namespace to real PHP
namespacing, meaning PHPUnit_Framework_TestCase has been changed to
PHPUnit\Framework\TestCase. PHPUnit 5.7 (old stable version) has a
compatibility layer allowing this to work in old versions, but the old
style namespacing won't work in new versions of PHPUnit.