### PR TITLE
Add support for conflicting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ Aliases: none
 
 Require that other $options be set for this option to be used.
 
+### `conflicts (string|array $options)`
+
+Aliases: none
+
+Require that other $options *not* be set for this option to be used.
+
 ### `must (Closure $rule)`
 
 Aliases: _N/A_

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $hello_cmd->option('c')
     ->aka('cap')
     ->describedAs('Always capitalize the words in a name')
     ->boolean();
-    
+
 // Define an incremental flag "-e" aka "--educate"
 $hello_cmd->option('e')
     ->aka('educate')
@@ -89,7 +89,7 @@ Running it:
 
     > php hello.php -c -t Mr 'nate good'
     Hello, Mr. Nate Good!
-    
+
     > php hello.php -ceet Mr 'nate good'
     Hello, Mr. Nate Good esq!
 

--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -112,6 +112,7 @@ class Command implements \ArrayAccess, \Iterator
         // mustBeInt
         // mustBeFloat
         'needs' => 'needs',
+        'conflicts' => 'conflicts',
 
         'file' => 'file',
         'expectsFile' => 'file',
@@ -262,6 +263,16 @@ class Command implements \ArrayAccess, \Iterator
     private function _needs(Option $option, $name)
     {
         return $option->setNeeds($name);
+    }
+
+    /**
+     * Set a conflict for an option.
+     * @param \Commando\Option $option Current option.
+     * @param string $name Name of conflicting option
+     * @return \Commando\Option instance
+     */
+    private function _conflicts(Option $option, $name) {
+        return $option->setConflicts($name);
     }
 
     /**
@@ -467,6 +478,16 @@ class Command implements \ArrayAccess, \Iterator
                 if ($needs !== true) {
                     throw new \InvalidArgumentException(
                         'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
+                    );
+                }
+            }
+
+            // See if our options conflict with each other
+            foreach ($this->options as $option) {
+                $conflicts = $option->hasConflicts($this->options);
+                if (false !== $conflicts) {
+                    throw new \InvalidArgumentException(
+                        'Option "' . $option->getName() . '" conflicts with options(s): ' . implode(', ', $conflicts)
                     );
                 }
             }

--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -100,7 +100,7 @@ class Command implements \ArrayAccess, \Iterator
         'mapTo' => 'map',
         'cast' => 'map',
         'castWith' => 'map',
-        
+
         'increment' => 'increment',
         'repeatable' => 'increment',
         'repeats' => 'increment',
@@ -314,7 +314,7 @@ class Command implements \ArrayAccess, \Iterator
     {
         return $option->setMap($callback);
     }
-    
+
     /**
      * @param Option $option
      * @param integer $max
@@ -391,14 +391,14 @@ class Command implements \ArrayAccess, \Iterator
                 $token = array_shift($tokens);
 
                 list($name, $type) = $this->_parseOption($token);
-                
+
                 // We allow short groups
                 if (strlen($name) > 1 && $type === self::OPTION_TYPE_SHORT) {
-                    
+
                     $group = str_split($name);
                     // correct option name
                     $name = array_shift($group);
-                    
+
                     // Iterate in reverse order to keep the option order correct
                     // options that don't require an argument can be mixed.
                     foreach(array_reverse($group) as $nextShort) {

--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -372,7 +372,7 @@ class Option
                 $notFound[] = $need;
             } elseif (!$optionsList[$need]->getValue()) {
                 // The needed option has been defined as a valid flag, but was
-                // not pased in by the user.
+                // not passed in by the user.
                 $notFound[] = $need;
             }
         }

--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -117,7 +117,7 @@ class Option
         $this->boolean = $bool;
         return $this;
     }
-    
+
     /**
      * @param int $max
      * @return Option
@@ -329,7 +329,7 @@ class Option
         // $this->value = false; // ?
         return $this->boolean;
     }
-    
+
     /**
      * @return bool is this option an incremental option
      */

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -139,7 +139,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->boolean();
         $this->assertTrue($cmd['b']);
     }
-    
+
     public function testIncrementOption()
     {
         $tokens = array('filename', '-vvvv');
@@ -148,10 +148,10 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->flag('v')
             ->aka('verbosity')
             ->increment();
-        
+
         $this->assertEquals(4, $cmd['verbosity']);
     }
-    
+
     public function testIncrementOptionMaxValue()
     {
         $tokens = array('filename', '-vvvv');
@@ -160,7 +160,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->flag('v')
             ->aka('verbosity')
             ->increment(3);
-            
+
         $this->assertEquals(3, $cmd['verbosity']);
     }
 

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -206,4 +206,37 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         ->needs('b');
     }
 
+    /**
+     * Test that conflicting options are resolved correctly.
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Option "a" conflicts with options(s): b, c
+     * @test
+     */
+    public function testConflictsErrorWhenPresent() {
+        $tokens = array('filename', '-a', '1', '-b', '2', '-c', '2');
+        $cmd = new Command($tokens);
+        $cmd->trapErrors(false)
+            ->beepOnError(false);
+        $cmd->option('a')->conflicts('b');
+        $cmd->option('a')->conflicts('c');
+        $cmd->option('b')->conflicts('a');
+        $cmd->option('c')->conflicts('a');
+    }
+
+    /**
+     * Test that conflicting options resolve when not conflicting.
+     * @test
+     */
+    public function testConflictsDontErrorWhenNotPresent() {
+        $tokens = array('filename', '-a', '1');
+        $cmd = new Command($tokens);
+        $cmd->trapErrors(false)
+            ->beepOnError(false);
+        $cmd->option('a')->conflicts('b');
+        $cmd->option('a')->conflicts('c');
+        $cmd->option('b')->conflicts('a');
+        $cmd->option('c')->conflicts('a');
+
+        $this->assertEquals($cmd['a'], '1');
+    }
 }

--- a/tests/Commando/OptionTest.php
+++ b/tests/Commando/OptionTest.php
@@ -196,7 +196,7 @@ class OptionTest extends \PHPUnit_Framework_TestCase
     {
         $option = new Option('conflicts');
         $option->setConflicts('other');
-        $optionsList = [];
+        $optionsList = array();
 
         $this->assertFalse($option->hasConflicts($optionsList));
     }
@@ -211,9 +211,9 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $option->setConflicts('other')->setValue(true);
         $conflict = new Option('other');
         $conflict->setValue(true);
-        $optionsList = [
+        $optionsList = array(
             'other' => $conflict,
-        ];
+        );
 
         $this->assertNotEmpty($option->hasConflicts($optionsList));
     }

--- a/tests/Commando/OptionTest.php
+++ b/tests/Commando/OptionTest.php
@@ -176,6 +176,48 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $option->hasNeeds($optionSet));
     }
 
+    /**
+     * Test setting a conflicting option.
+     * @test
+     */
+    public function testOptionConflicts()
+    {
+        $option = new Option('conflict');
+        $option->setConflicts('other');
+
+        $this->assertTrue(in_array('other', $option->getConflicts()));
+    }
+
+    /**
+     * Test hasConflicts when option does not have any conflicting options.
+     * @test
+     */
+    public function testOptionNoConflicts()
+    {
+        $option = new Option('conflicts');
+        $option->setConflicts('other');
+        $optionsList = [];
+
+        $this->assertFalse($option->hasConflicts($optionsList));
+    }
+
+    /**
+     * Test hasConflicts when option has a conflicting option.
+     * @test
+     */
+    public function testOptionHasConflicts()
+    {
+        $option = new Option('conflicts');
+        $option->setConflicts('other')->setValue(true);
+        $conflict = new Option('other');
+        $conflict->setValue(true);
+        $optionsList = [
+            'other' => $conflict,
+        ];
+
+        $this->assertNotEmpty($option->hasConflicts($optionsList));
+    }
+
     // Providers
 
     public function values()


### PR DESCRIPTION
Some options are mutually exclusive; passing both in should be an error. For example, if you're defining the environment a script should run against, you should not be able to pass both a --dev and --prod flag in.