### PR TITLE
Fix non-empty getArgumentValues array

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -640,9 +640,17 @@ class Command implements \ArrayAccess, \Iterator
     public function getArgumentValues()
     {
         $this->parseIfNotParsed();
+
+        $arguments = $this->arguments;
+        $arguments = array_filter($arguments, function(Option $argument){
+            $argumentValue = $argument->getValue();
+            return isset($argumentValue);
+        });
+
+
         return array_map(function(Option $argument) {
             return $argument->getValue();
-        }, $this->arguments);
+        }, $arguments);
     }
 
     /**

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -174,6 +174,13 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('v3', 'v4', 'v5'), $cmd->getArgumentValues());
         $this->assertEquals(array('a' => 'v1', 'b' => 'v2'), $cmd->getFlagValues());
+
+        $tokens = array('filename');
+        $cmd = new Command($tokens);
+        $cmd
+          ->argument();
+
+        $this->assertEmpty($cmd->getArgumentValues());
     }
 
     /**


### PR DESCRIPTION
Noticed that when using **anonymous arguments**, if you used the `argument()` method, `getArgumentValues()`wouldn't return an empty array. This fixes that.