### PR TITLE
Omit "<argument>" for incremental options

### DIFF
--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -440,7 +440,7 @@ class Option
                         '/-' : '/--') . $alias;
                 }
             }
-            if (!$this->isBoolean()) {
+            if (!$this->isBoolean() && !$this->isIncrement()) {
                 $help .= ' ' . $color->underline('<argument>');
             }
             $help .= PHP_EOL;


### PR DESCRIPTION
Options set to incremental should not show the "<argument>" placeholder in their help text.