### PR TITLE
Remove Support for 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ before_script:
   - composer install
   - cd tests
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2

--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -500,7 +500,7 @@ class Command implements \ArrayAccess, \Iterator
                 $needs = $option->hasNeeds($this->options);
                 if ($needs !== true) {
                     throw new \InvalidArgumentException(
-                        'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
+                        'Option "' . $option->getName() . '" does not have required option(s): ' . implode(', ', $needs)
                     );
                 }
             }


### PR DESCRIPTION
No longer support by Travis / Ubuntu and if anyone is still using 5.3 at this point, shame on you. This isn't technically a breaking change yet, but I think it's safe to say that with this change we can also start to adopt more modern PHP syntax and features from at least 5.4 forward. 