### PR TITLE
Display title if exists if a required argument is missing

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -489,9 +489,16 @@ class Command implements \ArrayAccess, \Iterator
             // todo protect against duplicates caused by aliases
             foreach ($this->options as $option) {
                 if (is_null($option->getValue()) && $option->isRequired()) {
-                    throw new \Exception(sprintf('Required %s %s must be specified',
-                        $option->getType() & Option::TYPE_NAMED ?
-                            'option' : 'argument', $option->getName()));
+                    $name = $option->getName();
+                    if ($option->getType() & Option::TYPE_NAMED) {
+                        $nature = 'option';
+                    } else {
+                        $nature = 'argument';
+                        if ($title = $option->getTitle()) {
+                            $name = $title;
+                        }
+                    }
+                    throw new \Exception(sprintf('Required %s %s must be specified', $nature, $name));
                 }
             }
 

--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -321,6 +321,14 @@ class Option
     }
 
     /**
+     * @return string title of the option
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
      * Get the current set of this option's requirements
      * @return string[] List of required options
      */


### PR DESCRIPTION
In the help screen, the title can be displayed instead of "arg 0". Add the same behavior on the error message when a required argument is missing.