### PR TITLE
Use titles for anonymous arguments where provided, doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,6 @@ If the value is not specified, default to `$defaultValue`.
 
 In the case of `boolean()` type flags, when the flag is present, the value of this option the negation of `$defaultValue`. That is to say, if you have a flag -b with a default of `true`, when -b is present as a command line flag, the value of the option will be `false`.
 
-### `file ()`
-
-Aliases: `expectsFile`
-
-The value specified for this option must be a valid file path. When used relative paths will be converted into fully quatified file paths and globbing is also optionally supported.  See the file.php example.
-
 ## Contributing
 
 Commando highly encourages sending in pull requests.  When submitting a pull request please:

--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -285,7 +285,7 @@ class Option
      */
     public function getName()
     {
-        return $this->name;
+        return ($this->title && is_numeric($this->name)) ? $this->title : $this->name;
     }
 
     /**

--- a/tests/Commando/OptionTest.php
+++ b/tests/Commando/OptionTest.php
@@ -29,7 +29,7 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($description, $option->getDescription());
     }
 
-    public function testAnnonymousOption()
+    public function testAnonymousOption()
     {
         $option = new Option(0);
 
@@ -41,6 +41,15 @@ class OptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $option->getName());
         $this->assertEquals($name, $named_option->getName());
         $this->assertEquals(1, $anon_option->getName());
+    }
+
+    public function testAnonymousOptionWithTitle()
+    {
+        $expected = 'test';
+        $option = new Option(0);
+        $option->setTitle($expected);
+
+        $this->assertEquals($expected, $option->getName());
     }
 
     public function testAddAlias()


### PR DESCRIPTION
Instead of "Required argument 0" when leaving off required anonymous
arguments, this will say "Required argument name" when ->title('name')
is added to the option builder chain.

Test added.

README.md updated to remove duplicate file listing.