### PR TITLE
Only evaluate 'needs' constraints of an option if that option is actually used.

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -495,10 +495,11 @@ class Command implements \ArrayAccess, \Iterator
                 }
             }
 
-            // See if our options have what they require
+            // See if our options have what they require.
+            // But only do so if the option is actually used
             foreach ($this->options as $option) {
                 $needs = $option->hasNeeds($this->options);
-                if ($needs !== true) {
+                if ($needs !== true && array_key_exists($option->getName(), $keyvals)) {
                     throw new \InvalidArgumentException(
                         'Option "' . $option->getName() . '" does not have required option(s): ' . implode(', ', $needs)
                     );


### PR DESCRIPTION
From the way I understood 'needs' it would create constraints that would make sure needed options that another option rely on are set. But the check seems to happen even if you haven't used the option that 'needs' the other options.

I, for instance, created an option to take an SMTP server host name.
Then I added options to supply username and password for that server if that was needed for the server. Using those options would 'need' the server address to be present.

But even if I didn't set the SMTP server or any of the username and password options it still complained about the need constraint. This made very little sense.

So I added a small check so it only evaluates 'needs' constraints of an option if that option is actually used.