### PR TITLE
Change Iterator to return keys based on option names.

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -898,12 +898,12 @@ class Command implements \ArrayAccess, \Iterator
     }
 
     /**
-     * @return int
+     * @return mixed current key
      * @see \Iterator
      */
     public function key()
     {
-        return $this->position;
+        return $this->sorted_keys[$this->position];
     }
 
     /**

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -248,4 +248,29 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Commando\Test\AnotherCommand', $cmd);
     }
+
+    public function testIterator()
+    {
+        $tokens = array('filename', '-vvvv', '-f', 'v1', '--long', 'v2', 'arg1', 'arg2');
+        $cmd = new Command($tokens);
+        $cmd->option('v')
+            ->aka('verbosity')
+            ->increment(3);
+        $cmd->flag('f');
+        $cmd->option('long');
+        $cmd->option('d')
+            ->default(12345);
+        $cmd->parse();
+
+        $expected = [
+            'arg1',
+            'arg2',
+            'd' => 12345,
+            'f' => 'v1',
+            'long' => 'v2',
+            'v' => 3,
+            'verbosity' => 3,
+        ];
+        $this->assertEquals($expected, \iterator_to_array($cmd));
+    }
 }


### PR DESCRIPTION
This is expected behaviour because ArrayAccess works in same manner.
As you can use $cmd['optionName'] to get value, you can do same
with $cmdArray = iterator_to_array($cmd); $cmdArray['optionName'].