### PR TITLE
Fix nil file being generated on help

### DIFF
--- a/src/Commando/Util/Terminal.php
+++ b/src/Commando/Util/Terminal.php
@@ -123,7 +123,7 @@ class Terminal
      */
     private static function isCommandFound ($commandName, $param)
     {
-        $trashPlace = 'nil';
+        $trashPlace = 'nul';
         if (self::isALinuxMachine()) {
           $trashPlace = '/dev/null';
         }


### PR DESCRIPTION
Fixes #103, displaying the help is generating a file called nil on windows in the current directory.  
