### PR TITLE
bypass exit on default help

### DIFF
--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -395,10 +395,12 @@ class Command implements \ArrayAccess, \Iterator
 
     /**
      * @param bool $help
+     * @return Command
      */
     public function useDefaultHelp($help = true)
     {
         $this->use_default_help = $help;
+        return $this;
     }
 
     /**

--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -68,6 +68,7 @@ class Command implements \ArrayAccess, \Iterator
         $help                       = null,
         $parsed                     = false,
         $use_default_help           = true,
+        $exit_after_help            = true,
         $trap_errors                = true,
         $beep_on_error              = true,
         $position                   = 0,
@@ -401,6 +402,19 @@ class Command implements \ArrayAccess, \Iterator
     }
 
     /**
+     * Allows to bypass the default behavior of exit()ing after
+     * displaying the default help screen.
+     *
+     * @param bool $exit
+     * @return Command
+     */
+    public function exitAfterHelp($exit)
+    {
+        $this->exit_after_help = $exit;
+        return $this;
+    }
+
+    /**
      * Rare that you would need to use this other than for testing,
      * allows defining the cli tokens, instead of using $argv
      * @param array $cli_tokens
@@ -477,7 +491,9 @@ class Command implements \ArrayAccess, \Iterator
                     // Short circuit if the help flag was set and we're using default help
                     if ($this->use_default_help === true && $name === 'help') {
                         $this->printHelp();
-                        exit;
+                        if ($this->exit_after_help) {
+                            exit;
+                        }
                     }
 
                     $option = $this->getOption($name);


### PR DESCRIPTION
By default when the help screen was printed the script is ended by `exit()`. There are cases were this behavior is undesired. The change allows to bypass this, the default behavior is unaffected.

Additionally I fixed `useDefaultHelp()` to match into the fluid interface.